### PR TITLE
Fix back gesture/button not working on Android 13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="false"
+        android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.MyApplication"
         tools:targetApi="tiramisu">
         <receiver


### PR DESCRIPTION
onBackPressed() defers to OnBackInvokedCallback on API 33+, but AndroidManifest.xml never set android:enableOnBackInvokedCallback, so the callback was never invoked.

> Added `android:enableOnBackInvokedCallback="true"` to the manifest.